### PR TITLE
Refactor: 상품 필터 로직을 ProductFilter 컴포넌트 내부로 캡슐화

### DIFF
--- a/src/components/Admin/EditProductModal.tsx
+++ b/src/components/Admin/EditProductModal.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { TfiClose } from "react-icons/tfi";
 import { editProduct } from "~/api/products";
 import { EditProductModalProps } from "~/types";
-import { SELECT_TAGS } from "~/constants";
+import { SELECT_TAGS } from "~/utils/constants";
 import Loading from "~/components/common/Loading";
 import Select from "~/components/common/Select";
 import styles from "~/styles/Admin/EditProductModal.module.scss";

--- a/src/components/Shop/ProductFilter.tsx
+++ b/src/components/Shop/ProductFilter.tsx
@@ -1,0 +1,46 @@
+import React, { useCallback } from "react";
+import styles from "~/styles/Shop/Shop.module.scss";
+import { ShopAllProduct } from "~/types";
+import { categorys } from "~/utils/constants";
+
+interface ProductFilterProps {
+  setAllProducts: React.Dispatch<React.SetStateAction<ShopAllProduct>>;
+  originalProducts: ShopAllProduct;
+}
+
+function ProductFilter({
+  setAllProducts,
+  originalProducts
+}: ProductFilterProps) {
+  // 상품 카테고리별 필터 기능
+  const handleCategoryFilter = useCallback(
+    (e: React.MouseEvent<HTMLInputElement>) => {
+      const category = (e.target as HTMLButtonElement).value;
+      if (category === "ALL") {
+        setAllProducts(originalProducts);
+      } else {
+        setAllProducts(
+          originalProducts.filter(product => product.tags === category)
+        );
+      }
+    },
+    [setAllProducts, originalProducts]
+  );
+
+  return (
+    <ul className={styles.menu}>
+      <li>
+        {categorys.map((category, index) => (
+          <input
+            key={`${category}-${index}`}
+            type="button"
+            defaultValue={category}
+            onClick={handleCategoryFilter}
+          />
+        ))}
+      </li>
+    </ul>
+  );
+}
+
+export default ProductFilter;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,0 @@
-export const SELECT_TAGS = [
-  {name: '태그를 선택해주세요.', value: ''},
-  {name: 'FURNITURE', value: 'FURNITURE'},
-  {name: 'KITCHEN', value: 'KITCHEN'},
-  {name: 'BEDROOM', value: 'BEDROOM'}
-]

--- a/src/routes/Admin/AdminProduct.tsx
+++ b/src/routes/Admin/AdminProduct.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { TiDeleteOutline } from "react-icons/ti";
 import { BsPencilSquare } from "react-icons/bs";
 import { addProduct, getAllProducts, deleteProduct } from "~/api/products";
-import { SELECT_TAGS } from "~/constants";
+import { SELECT_TAGS } from "~/utils/constants";
 import { convertPrice } from "~/utils/convert";
 import EditProductModal from "~/components/Admin/EditProductModal";
 import Select from "~/components/common/Select";

--- a/src/routes/Shop/Shop.tsx
+++ b/src/routes/Shop/Shop.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { getAllProducts } from "~/api/products";
+import ProductFilter from "~/components/Shop/ProductFilter";
 import ProductItem from "~/components/Shop/ProductItem";
 import styles from "~/styles/Shop/Shop.module.scss";
 import { ShopAllProduct, GetProduct } from "~/types";
@@ -7,13 +8,10 @@ import { ShopAllProduct, GetProduct } from "~/types";
 const Shop = () => {
   const [allProducts, setAllProducts] = useState<ShopAllProduct>([]);
   const [originalProducts, setOriginalProducts] = useState<ShopAllProduct>([]);
-  const [click] = useState(false);
 
   useEffect(() => {
     spreadAllProducts();
   }, []);
-
-  useEffect(() => {}, [allProducts]);
 
   const spreadAllProducts = async () => {
     try {
@@ -25,45 +23,14 @@ const Shop = () => {
     }
   };
 
-  // 상품 카테고리
-  const categorys = ["ALL", "FURNITURE", "KITCHEN", "BEDROOM"];
-
-  // 상품 카테고리별 필터 기능
-  const categoryHandler = (e: React.MouseEvent<HTMLInputElement>) => {
-    if ((e.target as HTMLButtonElement).value === "ALL") {
-      setAllProducts(originalProducts);
-    } else if ((e.target as HTMLButtonElement).value === "FURNITURE") {
-      setAllProducts(
-        originalProducts.filter(product => product.tags === "FURNITURE")
-      );
-    } else if ((e.target as HTMLButtonElement).value === "KITCHEN") {
-      setAllProducts(
-        originalProducts.filter(product => product.tags === "KITCHEN")
-      );
-    } else if ((e.target as HTMLButtonElement).value === "BEDROOM") {
-      setAllProducts(
-        originalProducts.filter(product => product.tags === "BEDROOM")
-      );
-    }
-  };
-
   return (
     <>
       <section className={styles.shop}>
         <div className={styles.menuWrap}>
-          <ul className={styles.menu}>
-            <li>
-              {categorys.map((category, index) => (
-                <input
-                  key={`${category}-${index}`}
-                  type="button"
-                  defaultValue={category}
-                  onClick={categoryHandler}
-                  className={click ? styles.active : ""}
-                />
-              ))}
-            </li>
-          </ul>
+          <ProductFilter
+            setAllProducts={setAllProducts}
+            originalProducts={originalProducts}
+          />
         </div>
         <div className={styles.productListWrap}>
           <ul className={styles.productList}>

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -1,0 +1,7 @@
+export const SELECT_TAGS = [
+  { name: "태그를 선택해주세요.", value: "" },
+  { name: "FURNITURE", value: "FURNITURE" },
+  { name: "KITCHEN", value: "KITCHEN" },
+  { name: "BEDROOM", value: "BEDROOM" }
+];
+export const categorys = ["ALL", "FURNITURE", "KITCHEN", "BEDROOM"];


### PR DESCRIPTION
## 작업 내용
- ProductFilter 컴포넌트를 별도로 분리
- 카테고리 필터링 로직이 단순화
- handleCategoryFilter 함수 메모이제이션
- constants 폴더 utils로 이동